### PR TITLE
Update Quadrant to 26.7.3-stable

### DIFF
--- a/dev.mrquantumoff.mcmodpackmanager.yml
+++ b/dev.mrquantumoff.mcmodpackmanager.yml
@@ -24,15 +24,15 @@ modules:
     buildsystem: simple
     sources:
       - type: file
-        url: https://github.com/quadrantmc/quadrant/raw/v26.7.2-stable/dev.mrquantumoff.mcmodpackmanager.metainfo.xml
-        sha256: 79676e260ef2b064d5376c12bdb33f1363e768ea08974573665a1e53744cbb88
+        url: https://github.com/quadrantmc/quadrant/raw/v26.7.3-stable/dev.mrquantumoff.mcmodpackmanager.metainfo.xml
+        sha256: b5d1602a5d8e2ff7452b949df2a0f97812c3ef85a75d0eb4f2073b654f5b6c21
       - type: file
-        url: https://github.com/quadrantmc/quadrant/releases/download/v26.7.2-stable/Quadrant_26.7.2-stable_amd64.deb
-        sha256: f15f818b7eebdfe6225597bb88c979cc4ca2baf2f893328effdb26558085246e
+        url: https://github.com/quadrantmc/quadrant/releases/download/v26.7.3-stable/Quadrant_26.7.3-stable_amd64.deb
+        sha256: 8ede62efb05d192f109548b0030dbeb61e4059388d6edbdb20aa595ce69c0d8b
         only-arches: [x86_64]
       - type: file
-        url: https://github.com/quadrantmc/quadrant/releases/download/v26.7.2-stable/Quadrant_26.7.2-stable_arm64.deb
-        sha256: a87e74e06f6ce93efe7df2f5ecf51e3548ef709db7234ee69881f31ce076eaa0
+        url: https://github.com/quadrantmc/quadrant/releases/download/v26.7.3-stable/Quadrant_26.7.3-stable_arm64.deb
+        sha256: def81ad6c6887ca067642d67becc449aa2ea1f02719521c522c59f291f61dc8c
         only-arches: [aarch64]
       - type: file
         path: run_quadrant


### PR DESCRIPTION
This PR was generated from the Quadrant release workflow after publishing the stable release assets.

- Tag: `v26.7.3-stable`
- Metainfo URL: `https://github.com/quadrantmc/quadrant/raw/v26.7.3-stable/dev.mrquantumoff.mcmodpackmanager.metainfo.xml`
- Metainfo SHA256: `b5d1602a5d8e2ff7452b949df2a0f97812c3ef85a75d0eb4f2073b654f5b6c21`
- amd64 URL: `https://github.com/quadrantmc/quadrant/releases/download/v26.7.3-stable/Quadrant_26.7.3-stable_amd64.deb`
- amd64 SHA256: `8ede62efb05d192f109548b0030dbeb61e4059388d6edbdb20aa595ce69c0d8b`
- arm64 URL: `https://github.com/quadrantmc/quadrant/releases/download/v26.7.3-stable/Quadrant_26.7.3-stable_arm64.deb`
- arm64 SHA256: `def81ad6c6887ca067642d67becc449aa2ea1f02719521c522c59f291f61dc8c`
